### PR TITLE
Add real estate landing page with Matterport embed

### DIFF
--- a/real-estate/index.html
+++ b/real-estate/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Real Estate Listings</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header>
+    <h1>Real Estate Listings</h1>
+  </header>
+  <section class="property">
+    <h2>Sample Property</h2>
+    <p class="address">123 Example St, Example City</p>
+    <p class="price">$500,000</p>
+    <div class="tour">
+      <iframe src="https://my.matterport.com/show/?m=QxFKpAVW8HG" allowfullscreen frameborder="0"></iframe>
+    </div>
+  </section>
+</body>
+</html>

--- a/real-estate/styles.css
+++ b/real-estate/styles.css
@@ -1,0 +1,27 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  background: #f5f5f5;
+}
+
+header {
+  background: #333;
+  color: #fff;
+  text-align: center;
+  padding: 1rem;
+}
+
+.property {
+  max-width: 900px;
+  margin: 2rem auto;
+  background: #fff;
+  padding: 1rem;
+  border: 1px solid #ccc;
+}
+
+.property .tour iframe {
+  width: 100%;
+  height: 480px;
+  border: 0;
+}


### PR DESCRIPTION
## Summary
- add `real-estate` landing page with Matterport tour and sample property details

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/@0x%2fsol-trace)
- `npm test` (fails: sh: 1: truffle: not found)


------
https://chatgpt.com/codex/tasks/task_e_688d550d668c832c93d1785a615267b3